### PR TITLE
console.log showing slider options in console deleted

### DIFF
--- a/autoform-nouislider.js
+++ b/autoform-nouislider.js
@@ -101,7 +101,6 @@ Template.afNoUiSlider.rendered = function () {
   var $s = template.$('.nouislider');
   template.autorun(function(){
     var options = calculateOptions( template );
-    console.log( options ); 
     $s.noUiSlider(options);
     $s.on({
       slide: function(){


### PR DESCRIPTION
get rid from unneeded data in browser console
