### PR TITLE
Reactivity, fixes, and code cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ elevatedevdesign:autoform-nouislider
 `meteor add elevatedevdesign:autoform-nouislider`
 
 ## Configuration
-Adds the `noUiSlider` type to autoform.  Specifying options passed as `noUiSliderOptions` will be passed directly to [nouislider](http://refreshless.com/nouislider/).  Currently only support's a range, though I'll accept a pull request to allow single values.
+Adds the `noUiSlider` type to [autoform](https://github.com/aldeed/meteor-autoform). It uses `min`, `max`, and `step` attributes like a normal slider, so it can be a drop in replacement, but options passed as `noUiSliderOptions` are passed directly to [nouislider](http://refreshless.com/nouislider/) for advanced control.
+
+### Simple Usage
+
+```
+{{> afFieldInput type="noUiSlider" name="foo" min=5 max=10 step=1}}
+```
 
 ### Single values
     CollectionSchema = new SimpleSchema({
@@ -14,9 +20,7 @@ Adds the `noUiSlider` type to autoform.  Specifying options passed as `noUiSlide
         min: 30,
         autoform: {
           type: "noUiSlider",
-          noUiSliderOptions: {
-            step: 10
-          },      
+          step: 10,    
           noUiSlider_pipsOptions: {
             mode: 'steps',
             density: 5
@@ -54,6 +58,9 @@ Adds the `noUiSlider` type to autoform.  Specifying options passed as `noUiSlide
       }
     });
 
+### Vertical Slider
+
+To get a vertical slider, do `noUiSliderOptions: {orientation: 'vertical'}` and specify an exact `height` in the CSS for the `nouislider` class.
 
 ### Overridding start and range
 You can override start and range by passing the options in.  

--- a/autoform-nouislider.js
+++ b/autoform-nouislider.js
@@ -1,10 +1,9 @@
-/* global AutoForm, _, $, Template */
+/* global AutoForm, _, Template */
 
 AutoForm.addInputType("noUiSlider", {
   template: "afNoUiSlider",
   valueOut: function(){
-    var elem = $(this[0]);
-    var slider = $(elem.find('.nouislider')[0]);
+    var slider = this.find('.nouislider');
     if( this.attr("data-type") === "Object" ){
       var first = parseInt(slider.val()[0]);
       var second = parseInt(slider.val()[1]);
@@ -21,96 +20,90 @@ AutoForm.addInputType("noUiSlider", {
 
 Template.afNoUiSlider.helpers({
   atts: function () {
-    var data = Template.instance().data;
+    var data = Template.currentData(); // get data reactively
     var atts = data.atts;
     atts["data-type"] = data.schemaType.name;
     if( atts["class"] ){
-      atts["class"] = atts["class"] + " at-nouislider";
+      atts["class"] += " at-nouislider";
     }else{
       atts["class"] = "at-nouislider";
     }
-    return _.omit(_.omit(atts, 'noUiSliderOptions'),'noUiSlider_pipsOptions'); 
+    return _.omit(atts, 'noUiSliderOptions', 'noUiSlider_pipsOptions');
   }
 });
 
+var calculateOptions = function(data){
+  var schemaMinMax = _.pick(data, 'max', 'min');
+  var autoformOptions = _.pick(data.atts || {}, 'max', 'min', 'step', 'start', 'range');
+  var noUiSliderOptions = (data.atts || {}).noUiSliderOptions;
 
-var calculateOptions = function(template){
-  var autoformOptions;
-  if( template.data && template.data.atts){
-    autoformOptions = template.data.atts;
-  }
-  
-  var options = {};
-  if( template.data.atts.noUiSliderOptions ){
-    options = _.extend({},template.data.atts.noUiSliderOptions);
-  }
+  var options = _.extend({}, schemaMinMax, autoformOptions, noUiSliderOptions);
 
   // Adjust data initalization based on schema type
   if( options.start === undefined ){
-    if( autoformOptions && autoformOptions.start ){
-      options.start = JSON.parse(autoformOptions.start);
-    }else{
-      var start;
-      if( template.data.schemaType.name === "Object" ){
-        if( template.data.value && template.data.value.lower ){
-          start = [
-            template.data.value.lower,
-            template.data.value.upper
-          ];
-        }else{
-          start = [
-            template.data.min ? template.data.min : 0, 
-            template.data.max ? template.data.max : 100
-          ];
-        }
-        options.connect = true;
+    if( data.schemaType.name === "Object" ){
+      if( data.value && data.value.lower ){
+        options.start = [
+          data.value.lower,
+          data.value.upper
+        ];
       }else{
-        if( template.data.value ){
-          start = template.data.value;
-        }else{
-          start = 0;
-        }
+        options.start = [
+          typeof data.min === "number" ? data.min : 0,
+          typeof data.max === "number" ? data.max : 100
+        ];
       }
-      options.start = start;
+      options.connect = true;
+    }else{
+      options.start = data.value || 0;
     }
+  } else {
+    options.start = JSON.parse(options.start);
   }
 
   if( options.range === undefined ){
-    if( autoformOptions && autoformOptions.range ){
-      options.range = JSON.parse(autoformOptions.range);
-    }else{
-      var range = {
-        min: template.data.min ? template.data.min : 0, 
-        max: template.data.max ? template.data.max : 100
-      };
-
-      options.range = range;
-    }
+    options.range = {
+      min: typeof options.min === "number" ? options.min : 0,
+      max: typeof options.max === "number" ? options.max : 100
+    };
+  } else {
+    options.range = JSON.parse(options.range);
   }
+  delete options.min;
+  delete options.max;
 
   // default step to 1 if not otherwise defined
-  if( !options.step ){
+  if( options.step === undefined ){
     options.step = 1;
   }
+
   return options;
 };
-
 
 Template.afNoUiSlider.rendered = function () {
   var template = this;
   var $s = template.$('.nouislider');
-  var setup = function(){
-    var options = calculateOptions( template );
-    $s.noUiSlider(options);
-    $s.on({
-      slide: function(){
+
+  var setup = function(c){
+    var data = Template.currentData(); // get data reactively
+    var options = calculateOptions( data );
+    $s.noUiSlider(options, true);
+
+    if (c.firstRun) {
+      $s.on('slide', function(){
+        // This is a trick to fool some logic in AutoForm that makes
+        // sure values have actually changed on whichever element
+        // emits a change event. Eventually AutoForm will give
+        // input types the control of indicating exactly when
+        // their value changes rather than relying on the change event
+        $s.parent()[0].value = JSON.stringify($s.val());
         $s.parent().change();
-      }
-    });
+      });
+    }
     
-    if( template.data.atts.noUiSlider_pipsOptions ){
+    if( data.atts.noUiSlider_pipsOptions ){
       $s.noUiSlider_pips(
-        template.data.atts.noUiSlider_pipsOptions
+        data.atts.noUiSlider_pipsOptions
       );
     }
   };


### PR DESCRIPTION
Hi, I had an old rough attempt at a package like this that I was going to clean up and publish, but since yours was pretty similar, I merged my logic with yours in this PR.

It adds reactive updating when attributes change, proper firing of AutoForm.getFieldValue, and ability to use `min`, `max`, and `step` from the attributes like with a normal slider. Hopefully everything it already did still works, too, but you may want to test a bit.

Fixes #1 and #5.
