### PR TITLE
Allow aldeed:template-extension@4.0.0

### DIFF
--- a/package.js
+++ b/package.js
@@ -8,7 +8,7 @@ Package.describe({
 Package.onUse(function(api) {
   api.use('templating@1.0.0');
   api.use('blaze@2.0.0');
-  api.use('aldeed:template-extension@3.4.3');
+  api.use('aldeed:template-extension@3.4.3 || 4.0.0');
   api.use('rcy:nouislider@7.0.7_2');
   api.use('aldeed:autoform@4.0.0 || 5.0.0');
   api.addFiles([


### PR DESCRIPTION
@aldeed has rewritten `aldeed:meteor-template-extension` and published version `4.0.0`.

The [README](https://github.com/aldeed/meteor-template-extension) now recommends using a 3.x.x release with Meteor 1.0.x or Meteor 1.1.x and 
using a 4.x.x release with Meteor 1.2+.
