### PR TITLE
Version update to support meteor 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-elevatedevdesign:autoform-nouislider
+muqube:autoform-nouislider
 =========================
 
 `meteor add elevatedevdesign:autoform-nouislider`
@@ -75,3 +75,6 @@ Show a label left and/or right of the slider
 ```
 {{> afFieldInput type="noUiSlider" name="foo" labelLeft="ugly" labelRight="delicious" min=0 max=1 step=0.1}}
 ```
+
+## History
+This meteor package is a fork of elevatedevdesign:autoform-nouislider. I forked it to make it compatible with meteor 1.3 and fix some bugs.

--- a/autoform-nouislider.js
+++ b/autoform-nouislider.js
@@ -116,9 +116,3 @@ Template.afNoUiSlider.rendered = function () {
   
   template.autorun( setup );
 };
-
-/*
- *  BOOTSTRAP THEME
- */
-
-Template.afNoUiSlider.copyAs('afNoUiSlider_bootstrap3');

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'elevatedevdesign:autoform-nouislider',
   summary: 'Dual value slider for autoform.',
-  version: '0.1.1',
+  version: '0.2.0',
   git: 'https://github.com/ElevateDevelopmentAndDesign/meteor-autoform-nouislider'
 });
 

--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  name: 'elevatedevdesign:autoform-nouislider',
+  name: 'muqube:autoform-nouislider',
   summary: 'Dual value slider for autoform.',
   version: '0.2.0',
   git: 'https://github.com/ElevateDevelopmentAndDesign/meteor-autoform-nouislider'

--- a/package.js
+++ b/package.js
@@ -6,9 +6,11 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
+  api.versionsFrom('METEOR@1.3');
+
   api.use('templating@1.0.0');
   api.use('blaze@2.0.0');
-  api.use('aldeed:template-extension@3.4.3');
+  api.use('aldeed:template-extension@4.0.0');
   api.use('rcy:nouislider@7.0.7_2');
   api.use('aldeed:autoform@4.0.0 || 5.0.0');
   api.addFiles([

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
   name: 'muqube:autoform-nouislider',
   summary: 'Dual value slider for autoform.',
-  version: '0.2.0',
+  version: '0.2.0_1',
   git: 'https://github.com/ElevateDevelopmentAndDesign/meteor-autoform-nouislider'
 });
 


### PR DESCRIPTION
This will solve https://github.com/ElevateDev/meteor-autoform-nouislider/issues/15.
Version of template-extensions in dependency list is updated, supported meteor version is updated to 1.3 as well.
I discovered that bootstrap theme support was causing a bug in rendering of the templates. 

> `Template.afNoUiSlider.copyAs('afNoUiSlider_bootstrap3');`

However, this template `afNoUiSlider_bootstrap3` was not used anywhere inside the package. Removing that line of code solved the rendering problem.
